### PR TITLE
Add tests for adstock and saturation components

### DIFF
--- a/pymc_marketing/mmm/components/adstock.py
+++ b/pymc_marketing/mmm/components/adstock.py
@@ -121,8 +121,8 @@ class WeibullAdstock(AdstockTransformation):
 
     def __init__(
         self,
-        l_max: int = 10,
-        normalize: bool = False,
+        l_max: int,
+        normalize: bool = True,
         kind=WeibullType.PDF,
         mode: ConvMode = ConvMode.After,
         priors: dict | None = None,
@@ -161,6 +161,15 @@ def _get_adstock_function(
     function: str | AdstockTransformation,
     **kwargs,
 ) -> AdstockTransformation:
+    """Helper for use in the MMM to get an adstock function."""
+    if isinstance(function, AdstockTransformation):
+        return function
+
+    if function not in ADSTOCK_TRANSFORMATIONS:
+        raise ValueError(
+            f"Unknown adstock function: {function}. Choose from {list(ADSTOCK_TRANSFORMATIONS.keys())}"
+        )
+
     if kwargs:
         warnings.warn(
             "The preferred method of initializing a lagging function is to use the class directly.",
@@ -168,7 +177,4 @@ def _get_adstock_function(
             stacklevel=1,
         )
 
-    if isinstance(function, str):
-        return ADSTOCK_TRANSFORMATIONS[function](**kwargs)
-
-    return function
+    return ADSTOCK_TRANSFORMATIONS[function](**kwargs)

--- a/pymc_marketing/mmm/components/base.py
+++ b/pymc_marketing/mmm/components/base.py
@@ -131,6 +131,7 @@ class Transformation:
         new_priors = {
             parameter_name: priors[variable_name]
             for parameter_name, variable_name in self.variable_mapping.items()
+            if variable_name in priors
         }
         if not new_priors:
             available_priors = list(self.variable_mapping.values())

--- a/pymc_marketing/mmm/components/saturation.py
+++ b/pymc_marketing/mmm/components/saturation.py
@@ -164,7 +164,13 @@ SATURATION_TRANSFORMATIONS: dict[str, type[SaturationTransformation]] = {
 def _get_saturation_function(
     function: str | SaturationTransformation,
 ) -> SaturationTransformation:
-    if isinstance(function, str):
-        return SATURATION_TRANSFORMATIONS[function]()
+    """Helper for use in the MMM to get a saturation function."""
+    if isinstance(function, SaturationTransformation):
+        return function
 
-    return function
+    if function not in SATURATION_TRANSFORMATIONS:
+        raise ValueError(
+            f"Unknown saturation function: {function}. Choose from {list(SATURATION_TRANSFORMATIONS.keys())}"
+        )
+
+    return SATURATION_TRANSFORMATIONS[function]()

--- a/tests/mmm/components/test_adstock.py
+++ b/tests/mmm/components/test_adstock.py
@@ -89,6 +89,17 @@ def test_get_adstock_function(name, adstock_cls, kwargs):
     assert isinstance(adstock, adstock_cls)
 
 
+@pytest.mark.parametrize(
+    "adstock",
+    adstocks(),
+)
+def test_get_adstock_function_passthrough(adstock) -> None:
+    id_before = id(adstock)
+    id_after = id(_get_adstock_function(adstock))
+
+    assert id_after == id_before
+
+
 def test_get_adstock_function_unknown():
     with pytest.raises(
         ValueError, match="Unknown adstock function: Unknown. Choose from"

--- a/tests/mmm/components/test_adstock.py
+++ b/tests/mmm/components/test_adstock.py
@@ -11,3 +11,86 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+
+from pymc_marketing.mmm.components.adstock import (
+    AdstockTransformation,
+    DelayedAdstock,
+    GeometricAdstock,
+    WeibullAdstock,
+    _get_adstock_function,
+)
+
+
+def adstocks() -> list[AdstockTransformation]:
+    return [
+        DelayedAdstock(l_max=10),
+        GeometricAdstock(l_max=10),
+        WeibullAdstock(l_max=10, kind="PDF"),
+        WeibullAdstock(l_max=10, kind="CDF"),
+    ]
+
+
+@pytest.fixture
+def model() -> pm.Model:
+    coords = {"channel": ["a", "b", "c"]}
+    return pm.Model(coords=coords)
+
+
+x = np.zeros(20)
+x[0] = 1
+
+
+@pytest.mark.parametrize(
+    "adstock",
+    adstocks(),
+)
+@pytest.mark.parametrize(
+    "x, dims",
+    [
+        (x, None),
+        (np.broadcast_to(x, (3, 20)).T, "channel"),
+    ],
+)
+def test_apply(model, adstock, x, dims) -> None:
+    with model:
+        y = adstock.apply(x, dim_name=dims)
+
+    assert isinstance(y, pt.TensorVariable)
+    assert y.eval().shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "adstock",
+    adstocks(),
+)
+def test_default_prefix(adstock) -> None:
+    assert adstock.prefix == "adstock"
+    for value in adstock.variable_mapping.values():
+        assert value.startswith("adstock_")
+
+
+@pytest.mark.parametrize(
+    "name, adstock_cls, kwargs",
+    [
+        ("delayed", DelayedAdstock, {"l_max": 10}),
+        ("geometric", GeometricAdstock, {"l_max": 10}),
+        ("weibull", WeibullAdstock, {"l_max": 10}),
+    ],
+)
+def test_get_adstock_function(name, adstock_cls, kwargs):
+    # Test for a warning
+    with pytest.warns(DeprecationWarning, match="The preferred method of initializing"):
+        adstock = _get_adstock_function(name, **kwargs)
+
+    assert isinstance(adstock, adstock_cls)
+
+
+def test_get_adstock_function_unknown():
+    with pytest.raises(
+        ValueError, match="Unknown adstock function: Unknown. Choose from"
+    ):
+        _get_adstock_function(function="Unknown")

--- a/tests/mmm/components/test_saturation.py
+++ b/tests/mmm/components/test_saturation.py
@@ -11,3 +11,111 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from inspect import signature
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+
+from pymc_marketing.mmm.components.saturation import (
+    HillSaturation,
+    LogisticSaturation,
+    MichaelisMentenSaturation,
+    TanhSaturation,
+    TanhSaturationBaselined,
+    _get_saturation_function,
+)
+
+
+@pytest.fixture
+def model() -> pm.Model:
+    coords = {"channel": ["a", "b", "c"]}
+    return pm.Model(coords=coords)
+
+
+def saturation_functions():
+    return [
+        LogisticSaturation(),
+        TanhSaturation(),
+        TanhSaturationBaselined(),
+        MichaelisMentenSaturation(),
+        HillSaturation(),
+    ]
+
+
+@pytest.mark.parametrize(
+    "saturation",
+    saturation_functions(),
+)
+@pytest.mark.parametrize(
+    "x, dims",
+    [
+        (np.linspace(0, 1, 100), None),
+        (np.ones((100, 3)), "channel"),
+    ],
+)
+def test_apply_method(model, saturation, x, dims) -> None:
+    with model:
+        y = saturation.apply(x, dim_name=dims)
+
+    assert isinstance(y, pt.TensorVariable)
+    assert y.eval().shape == x.shape
+
+
+@pytest.mark.parametrize(
+    "saturation",
+    saturation_functions(),
+)
+def test_default_prefix(saturation) -> None:
+    assert saturation.prefix == "saturation"
+    for value in saturation.variable_mapping.values():
+        assert value.startswith("saturation_")
+
+
+@pytest.mark.parametrize(
+    "saturation",
+    saturation_functions(),
+)
+def test_support_for_lift_test_integrations(saturation) -> None:
+    function_parameters = signature(saturation.function).parameters
+
+    for key in saturation.variable_mapping.keys():
+        assert isinstance(key, str)
+        assert key in function_parameters
+
+    assert len(saturation.variable_mapping) == len(function_parameters) - 1
+
+
+@pytest.mark.parametrize(
+    "name, saturation_cls",
+    [
+        ("logistic", LogisticSaturation),
+        ("tanh", TanhSaturation),
+        ("tanh_baselined", TanhSaturationBaselined),
+        ("michaelis_menten", MichaelisMentenSaturation),
+        ("hill", HillSaturation),
+    ],
+)
+def test_get_saturation_function(name, saturation_cls) -> None:
+    saturation = _get_saturation_function(name)
+
+    assert isinstance(saturation, saturation_cls)
+
+
+@pytest.mark.parametrize(
+    "saturation",
+    saturation_functions(),
+)
+def test_get_saturation_function_passthrough(saturation) -> None:
+    id_before = id(saturation)
+    id_after = id(_get_saturation_function(saturation))
+
+    assert id_after == id_before
+
+
+def test_get_saturation_function_unknown() -> None:
+    with pytest.raises(
+        ValueError, match="Unknown saturation function: unknown. Choose from"
+    ):
+        _get_saturation_function("unknown")


### PR DESCRIPTION
<!-- !! Thank your for opening a PR !! -->

<!--- Provide a self-contained summary of your changes in the Title above -->
<!--- This is what will be shown in the automatic release notes: https://github.com/pymc-labs/pymc-marketing/releases -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- It is good practice to first open an issue explaining the bug / new feature that is addressed by this PR -->
<!--- Please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
- [ ] Closes #
- [ ] Related to #

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
- [ ] Checked that [the pre-commit linting/style checks pass](https://docs.pymc.io/en/latest/contributing/python_style.html)
- [ ] Included tests that prove the fix is effective or that the new feature works
- [ ] Added necessary documentation (docstrings and/or example notebooks)
- [ ] If you are a pro: each commit corresponds to a [relevant logical change](https://wiki.openstack.org/wiki/GitCommitMessages#Structural_split_of_changes)
<!--- You may find this guide helpful: https://mainmatter.com/blog/2021/05/26/keeping-a-clean-git-history/ -->

## Modules affected
<!--- Please list the modules that are affected by this PR by typing an `x` in the boxes below: -->
- [ ] MMM
- [ ] CLV
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->

## Type of change
<!--- Select one of the categories below by typing an `x` in the box -->
- [ ] New feature / enhancement
- [ ] Bug fix
- [ ] Documentation
- [ ] Maintenance
- [ ] Other (please specify):
<!--- Additionally, if you are a maintainer or reviewer, please make sure that the appropriate labels are added to this PR -->


<!-- readthedocs-preview pymc-marketing start -->
----
📚 Documentation preview 📚: https://pymc-marketing--5.org.readthedocs.build/en/5/

<!-- readthedocs-preview pymc-marketing end -->